### PR TITLE
Update azure-openai-chat.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
@@ -37,13 +37,13 @@ This Azure configuration will align with the default configurations of the Sprin
 If you use a different Deployment Name, update the configuration property accordingly:
 
 ```
-spring.ai.azure.openai.chat.options.model=<my deployment name>
+spring.ai.azure.openai.chat.options.deployment-name=<my deployment name>
 ```
 
 The different deployment structures of Azure OpenAI and OpenAI leads to a property in the Azure OpenAI client library named `deploymentOrModelName`.
 This is because in OpenAI there is no `Deployment Name`, only a `Model Name`.
 
-In a subsequent release, Spring AI will rename the property `spring.ai.azure.openai.chat.options.model` to `spring.ai.azure.openai.chat.options.deployment-name` to avoid confusion.
+NOTE: The property `spring.ai.azure.openai.chat.options.model` has been renamed to `spring.ai.azure.openai.chat.options.deployment-name`.
 
 === Add Repositories and BOM
 
@@ -151,7 +151,7 @@ Add a `application.properties` file, under the `src/main/resources` directory, t
 ----
 spring.ai.azure.openai.api-key=YOUR_API_KEY
 spring.ai.azure.openai.endpoint=YOUR_ENDPOINT
-spring.ai.azure.openai.chat.options.model=gpt-35-turbo
+spring.ai.azure.openai.chat.options.deployment-name=gpt-35-turbo
 spring.ai.azure.openai.chat.options.temperature=0.7
 ----
 


### PR DESCRIPTION
In v0.8.1, the property spring.ai.azure.openai.chat.options.model does not exist anymore. I have tried with spring.ai.azure.openai.chat.options.deployment-name and am able to connect to the Azure Open AI service.

Considering spring.ai.azure.openai.chat.options.deployment-name is the correct property name, I have updated the document to reflect this.

I have also removed this statement "In a subsequent release, Spring AI will rename the property spring.ai.azure.openai.chat.options.model to spring.ai.azure.openai.chat.options.deployment-name to avoid confusion." as this has already been renamed. I have added an appropriate note related to this.

@pivotal-cla This is an Obvious Fix.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
